### PR TITLE
Fix SOQL keywords

### DIFF
--- a/com.salesforce.ide.ui.editors/config/static-editor-content.xml
+++ b/com.salesforce.ide.ui.editors/config/static-editor-content.xml
@@ -195,6 +195,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 		<value>array</value>
 		<value>as</value>
 		<value>asc</value>
+		<value>ASC</value>
 		<value>autonomous</value>
 		<value>begin</value>
 		<value>bigdecimal</value>
@@ -224,6 +225,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 		<value>default</value>
 		<value>delete</value>
 		<value>desc</value>
+		<value>DESC</value>
 		<value>division</value>
 		<value>do</value>
 		<value>else</value>
@@ -267,6 +269,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 		<value>last_week</value>
 		<value>like</value>
 		<value>limit</value>
+		<value>LIMIT</value>
 		<value>list</value>
 		<value>long</value>
 		<value>loop</value>
@@ -287,6 +290,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 		<value>on</value>
 		<value>or</value>
 		<value>order</value>
+		<value>ORDER</value>
 		<value>outer</value>
 		<value>override</value>
 		<value>phrase</value>

--- a/com.salesforce.ide.ui.editors/config/static-editor-content.xml
+++ b/com.salesforce.ide.ui.editors/config/static-editor-content.xml
@@ -352,7 +352,6 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 		<value>first</value>
 		<value>includes</value>
 		<value>last</value>
-		<value>order</value>
 		<value>sharing</value>
 		<value>with</value>
 		<value>without</value>


### PR DESCRIPTION
I've included a uppercase option for several SOQL keywords which were missing.
I've also deleted a duplicated "order" SOQL keyword definition.

If there's any reason not to have a upppercase version of the keywords included in this pull, I'd like to know what's the reason (convention, good practises, etc) behind that reasoning. Otherwise, I think this would be a nice addition.
