### PR TITLE
Added project preference to bypass 'Save to Server' action's dirty file check.

### DIFF
--- a/com.salesforce.ide.core/src/com/salesforce/ide/core/internal/utils/Constants.java
+++ b/com.salesforce.ide.core/src/com/salesforce/ide/core/internal/utils/Constants.java
@@ -222,6 +222,7 @@ public interface Constants {
     String PROP_IDE_VERSION = "ideVersion";
     String PROP_PROJECT_IDENTIFIER = "projectIdentifier";
     String PROP_PREFER_TOOLING_DEPLOYMENT = "preferToolingDeployment";
+    String PROP_DISABLE_SAVE_TO_SERVER_DIRTY_RESOURCE_CHECK = "disableSaveToServerDirtyResourceCheck";
 
     // P R O J E C T
     String LOGGING_LEVEL = "loggingLevel";

--- a/com.salesforce.ide.core/src/com/salesforce/ide/core/project/ForceProject.java
+++ b/com.salesforce.ide.core/src/com/salesforce/ide/core/project/ForceProject.java
@@ -41,6 +41,7 @@ public class ForceProject extends Org {
     private String ideVersion = null;
     private String projectIdentifier = null;
     private boolean preferToolingDeployment = true;
+    private boolean disableSaveToServerDirtyResourceCheck = false;
     private String[] enabledComponentTypes;
 
     //   C O N S T R U C T O R S
@@ -126,6 +127,15 @@ public class ForceProject extends Org {
     public void setPreferToolingDeployment(boolean isPreferred) {
         preferToolingDeployment = isPreferred;
     }
+    
+    public boolean getDisableSaveToServerDirtyResourceCheck() {
+        return disableSaveToServerDirtyResourceCheck;
+    }
+    
+    public void setDisableSaveToServerDirtyResourceCheck(boolean bValue) {
+        disableSaveToServerDirtyResourceCheck = bValue;
+    }
+    
 
     @Override
     public String getFullLogDisplay() {

--- a/com.salesforce.ide.core/src/com/salesforce/ide/core/services/ProjectService.java
+++ b/com.salesforce.ide.core/src/com/salesforce/ide/core/services/ProjectService.java
@@ -1632,6 +1632,7 @@ public class ProjectService extends BaseService {
 
         forceProject.setKeepEndpoint(preferences.getBoolean(Constants.PROP_KEEP_ENDPOINT, false));
         forceProject.setPreferToolingDeployment(preferences.getBoolean(Constants.PROP_PREFER_TOOLING_DEPLOYMENT, true));
+        forceProject.setDisableSaveToServerDirtyResourceCheck(preferences.getBoolean(Constants.PROP_DISABLE_SAVE_TO_SERVER_DIRTY_RESOURCE_CHECK, false));
         forceProject.setHttpsProtocol(preferences.getBoolean(Constants.PROP_HTTPS_PROTOCOL, true));
         forceProject.setReadTimeoutSecs(preferences.getInt(Constants.PROP_READ_TIMEOUT,
             Constants.READ_TIMEOUT_IN_SECONDS_DEFAULT));
@@ -1762,6 +1763,7 @@ public class ProjectService extends BaseService {
         setBoolean(project, Constants.PROP_KEEP_ENDPOINT, forceProject.isKeepEndpoint());
         setBoolean(project, Constants.PROP_HTTPS_PROTOCOL, forceProject.isHttpsProtocol());
         setBoolean(project, Constants.PROP_PREFER_TOOLING_DEPLOYMENT, forceProject.getPreferToolingDeployment());
+        setBoolean(project, Constants.PROP_DISABLE_SAVE_TO_SERVER_DIRTY_RESOURCE_CHECK, forceProject.getDisableSaveToServerDirtyResourceCheck());
         setInt(project, Constants.PROP_READ_TIMEOUT, forceProject.getReadTimeoutSecs());
 
         Map<String, String> credentialMap = new HashMap<>();

--- a/com.salesforce.ide.ui/src/com/salesforce/ide/ui/actions/SaveToServerActionController.java
+++ b/com.salesforce.ide.ui/src/com/salesforce/ide/ui/actions/SaveToServerActionController.java
@@ -156,10 +156,17 @@ public class SaveToServerActionController extends ActionController {
     }
 
     @VisibleForTesting
+    // false implies resource is dirty, true implies resource is clean
     protected boolean checkForDirtyResources() {
         if (Utils.isEmpty(selectedResources)) {
             logger.info("Operation cancelled.  Resources not provided.");
             return false;
+        }
+
+        
+        if (getProjectService().getForceProject(project).getDisableSaveToServerDirtyResourceCheck() == true) {
+        	logger.info("Preference set to skip dirty resource (`checkForDirtyResources(...)` check.");
+        	return true;
         }
 
         for (IResource selectedResource : selectedResources) {
@@ -167,7 +174,7 @@ public class SaveToServerActionController extends ActionController {
             if (dirty) {
                 boolean result =
                         !Utils.openQuestion("Confirm Save Dirty Resource", "Save resource '"
-                                + selectedResource.getName() + "' is dirty.\n\n" + "Continue to save to server?");
+                                + selectedResource.getName() + "' is dirty.\n\n" + "Continue to save to server?\n\nThis behaviour can be disabled in project's preferences.");
                 if (result) {
                     return false;
                 }

--- a/com.salesforce.ide.ui/src/com/salesforce/ide/ui/internal/utils/messages.properties
+++ b/com.salesforce.ide.ui/src/com/salesforce/ide/ui/internal/utils/messages.properties
@@ -206,6 +206,7 @@ Deployment.SyncCheckError.message=Unable to perform synchronize check with remot
 
 # deployment options
 DeploymentOptions_UseToolingAPI=Use Tooling API deploy path when possible
+DeploymentOptions_DisableSaveToServerDirtyResourceCheck=Disable 'Save to Server' dirty resource check
 
 # component create wizards
 ApexCodeWizard.ApexEnabled.error={0} is not enabled in this project.  Check permission and connection settings.

--- a/com.salesforce.ide.ui/src/com/salesforce/ide/ui/properties/DeploymentOptions.java
+++ b/com.salesforce.ide.ui/src/com/salesforce/ide/ui/properties/DeploymentOptions.java
@@ -35,6 +35,7 @@ import com.salesforce.ide.ui.internal.utils.UIMessages;
 public class DeploymentOptions extends BasePropertyPage {
 
     private Button preferToolingDeploymentCheckbox;
+    private Button disableSaveToServerDirtyResourceCheckCheckbox;
     private ProjectController projectController = null;
     private ForceProject forceProject;
 
@@ -73,6 +74,9 @@ public class DeploymentOptions extends BasePropertyPage {
         preferToolingDeploymentCheckbox = new Button(deploymentComposite, SWT.CHECK);
         preferToolingDeploymentCheckbox.setText(UIMessages.getString("DeploymentOptions_UseToolingAPI"));
 
+        disableSaveToServerDirtyResourceCheckCheckbox = new Button(deploymentComposite, SWT.CHECK);
+        disableSaveToServerDirtyResourceCheckCheckbox.setText(UIMessages.getString("DeploymentOptions_DisableSaveToServerDirtyResourceCheck"));;
+        
         loadFromPreferences();
 
         return deploymentComposite;
@@ -82,6 +86,8 @@ public class DeploymentOptions extends BasePropertyPage {
         forceProject = getProjectService().getForceProject(getProject());
         boolean preferToolingDeployment = forceProject.getPreferToolingDeployment();
         preferToolingDeploymentCheckbox.setSelection(preferToolingDeployment);
+        
+        disableSaveToServerDirtyResourceCheckCheckbox.setSelection(forceProject.getDisableSaveToServerDirtyResourceCheck());
 
         projectController.getProjectModel().setForceProject(forceProject);
     }
@@ -90,6 +96,7 @@ public class DeploymentOptions extends BasePropertyPage {
     public boolean performOk() {
         try {
             forceProject.setPreferToolingDeployment(preferToolingDeploymentCheckbox.getSelection());
+            forceProject.setDisableSaveToServerDirtyResourceCheck(disableSaveToServerDirtyResourceCheckCheckbox.getSelection());
             projectController.saveSettings(new NullProgressMonitor());
         } catch (InterruptedException e) {
             // Not possible with a NullProgressMonitor


### PR DESCRIPTION
Most of my work is performed in a team environment hence I always develop in 'Offline' mode as in Online mode any pulls from GIT repo resolve in automatic build push to org. This means that I have to manually specify 'Right click > Force.com > Save to Server' which is rather slow due to the forced checks.

This patch (more to follow) allows for disabling of the dirty file check on per project level. Any chance this can make it into the official product?

![disable save to server project pref](https://cloud.githubusercontent.com/assets/273413/16898007/6bb9072a-4b94-11e6-82bc-071dc0394036.png)

![dialog extra info](https://cloud.githubusercontent.com/assets/273413/16898009/7caa8180-4b94-11e6-9f35-533d16a71132.png)
