### PR TITLE
GitHub pull type save error package visiblity type is not visible

### DIFF
--- a/com.salesforce.ide.core/src/com/salesforce/ide/core/internal/utils/Constants.java
+++ b/com.salesforce.ide.core/src/com/salesforce/ide/core/internal/utils/Constants.java
@@ -222,6 +222,7 @@ public interface Constants {
     String PROP_IDE_VERSION = "ideVersion";
     String PROP_PROJECT_IDENTIFIER = "projectIdentifier";
     String PROP_PREFER_TOOLING_DEPLOYMENT = "preferToolingDeployment";
+    String PROP_DISABLE_SAVE_TO_SERVER_DIRTY_RESOURCE_CHECK = "disableSaveToServerDirtyResourceCheck";
 
     // P R O J E C T
     String LOGGING_LEVEL = "loggingLevel";

--- a/com.salesforce.ide.core/src/com/salesforce/ide/core/project/ForceProject.java
+++ b/com.salesforce.ide.core/src/com/salesforce/ide/core/project/ForceProject.java
@@ -41,6 +41,7 @@ public class ForceProject extends Org {
     private String ideVersion = null;
     private String projectIdentifier = null;
     private boolean preferToolingDeployment = true;
+    private boolean disableSaveToServerDirtyResourceCheck = false;
     private String[] enabledComponentTypes;
 
     //   C O N S T R U C T O R S
@@ -126,6 +127,15 @@ public class ForceProject extends Org {
     public void setPreferToolingDeployment(boolean isPreferred) {
         preferToolingDeployment = isPreferred;
     }
+    
+    public boolean getDisableSaveToServerDirtyResourceCheck() {
+        return disableSaveToServerDirtyResourceCheck;
+    }
+    
+    public void setDisableSaveToServerDirtyResourceCheck(boolean bValue) {
+        disableSaveToServerDirtyResourceCheck = bValue;
+    }
+    
 
     @Override
     public String getFullLogDisplay() {

--- a/com.salesforce.ide.core/src/com/salesforce/ide/core/project/ForceProject.java
+++ b/com.salesforce.ide.core/src/com/salesforce/ide/core/project/ForceProject.java
@@ -40,7 +40,7 @@ public class ForceProject extends Org {
     private IProject project = null;
     private String ideVersion = null;
     private String projectIdentifier = null;
-    private boolean preferToolingDeployment = true;
+    private boolean preferToolingDeployment = false;
     private boolean disableSaveToServerDirtyResourceCheck = false;
     private String[] enabledComponentTypes;
 

--- a/com.salesforce.ide.core/src/com/salesforce/ide/core/services/ProjectService.java
+++ b/com.salesforce.ide.core/src/com/salesforce/ide/core/services/ProjectService.java
@@ -1632,6 +1632,7 @@ public class ProjectService extends BaseService {
 
         forceProject.setKeepEndpoint(preferences.getBoolean(Constants.PROP_KEEP_ENDPOINT, false));
         forceProject.setPreferToolingDeployment(preferences.getBoolean(Constants.PROP_PREFER_TOOLING_DEPLOYMENT, true));
+        forceProject.setDisableSaveToServerDirtyResourceCheck(preferences.getBoolean(Constants.PROP_DISABLE_SAVE_TO_SERVER_DIRTY_RESOURCE_CHECK, false));
         forceProject.setHttpsProtocol(preferences.getBoolean(Constants.PROP_HTTPS_PROTOCOL, true));
         forceProject.setReadTimeoutSecs(preferences.getInt(Constants.PROP_READ_TIMEOUT,
             Constants.READ_TIMEOUT_IN_SECONDS_DEFAULT));
@@ -1762,6 +1763,7 @@ public class ProjectService extends BaseService {
         setBoolean(project, Constants.PROP_KEEP_ENDPOINT, forceProject.isKeepEndpoint());
         setBoolean(project, Constants.PROP_HTTPS_PROTOCOL, forceProject.isHttpsProtocol());
         setBoolean(project, Constants.PROP_PREFER_TOOLING_DEPLOYMENT, forceProject.getPreferToolingDeployment());
+        setBoolean(project, Constants.PROP_DISABLE_SAVE_TO_SERVER_DIRTY_RESOURCE_CHECK, forceProject.getDisableSaveToServerDirtyResourceCheck());
         setInt(project, Constants.PROP_READ_TIMEOUT, forceProject.getReadTimeoutSecs());
 
         Map<String, String> credentialMap = new HashMap<>();

--- a/com.salesforce.ide.ui/src/com/salesforce/ide/ui/actions/SaveToServerActionController.java
+++ b/com.salesforce.ide.ui/src/com/salesforce/ide/ui/actions/SaveToServerActionController.java
@@ -156,10 +156,17 @@ public class SaveToServerActionController extends ActionController {
     }
 
     @VisibleForTesting
+    // false implies resource is dirty, true implies resource is clean
     protected boolean checkForDirtyResources() {
         if (Utils.isEmpty(selectedResources)) {
             logger.info("Operation cancelled.  Resources not provided.");
             return false;
+        }
+
+        
+        if (getProjectService().getForceProject(project).getDisableSaveToServerDirtyResourceCheck() == true) {
+        	logger.info("Preference set to skip dirty resource (`checkForDirtyResources(...)` check.");
+        	return true;
         }
 
         for (IResource selectedResource : selectedResources) {
@@ -167,7 +174,7 @@ public class SaveToServerActionController extends ActionController {
             if (dirty) {
                 boolean result =
                         !Utils.openQuestion("Confirm Save Dirty Resource", "Save resource '"
-                                + selectedResource.getName() + "' is dirty.\n\n" + "Continue to save to server?");
+                                + selectedResource.getName() + "' is dirty.\n\n" + "Continue to save to server?\n\nThis behaviour can be disabled in project's preferences.");
                 if (result) {
                     return false;
                 }

--- a/com.salesforce.ide.ui/src/com/salesforce/ide/ui/internal/utils/messages.properties
+++ b/com.salesforce.ide.ui/src/com/salesforce/ide/ui/internal/utils/messages.properties
@@ -205,7 +205,7 @@ Deployment.SyncCheckError.title=Synchronize Check Failed
 Deployment.SyncCheckError.message=Unable to perform synchronize check with remote server.\n\n{0}\n\nYour project may be out-of-sync.
 
 # deployment options
-DeploymentOptions_UseToolingAPI=Use Tooling API deploy path when possible
+DeploymentOptions_UseToolingAPI=Use Tooling API deploy path when possible (can cause issues, see: https://github.com/forcedotcom/idecore/issues/178)
 DeploymentOptions_DisableSaveToServerDirtyResourceCheck=Disable 'Save to Server' dirty resource check
 
 # component create wizards

--- a/com.salesforce.ide.ui/src/com/salesforce/ide/ui/internal/utils/messages.properties
+++ b/com.salesforce.ide.ui/src/com/salesforce/ide/ui/internal/utils/messages.properties
@@ -206,6 +206,7 @@ Deployment.SyncCheckError.message=Unable to perform synchronize check with remot
 
 # deployment options
 DeploymentOptions_UseToolingAPI=Use Tooling API deploy path when possible
+DeploymentOptions_DisableSaveToServerDirtyResourceCheck=Disable 'Save to Server' dirty resource check
 
 # component create wizards
 ApexCodeWizard.ApexEnabled.error={0} is not enabled in this project.  Check permission and connection settings.

--- a/com.salesforce.ide.ui/src/com/salesforce/ide/ui/properties/DeploymentOptions.java
+++ b/com.salesforce.ide.ui/src/com/salesforce/ide/ui/properties/DeploymentOptions.java
@@ -24,10 +24,10 @@ import com.salesforce.ide.core.project.ProjectController;
 import com.salesforce.ide.ui.internal.utils.UIMessages;
 
 /**
- * Preference page for controlling the deployment options. As of v31, we are letting the user decide if they would
- * prefer to use the Tooling API path when applicable (default). The Tooling API is faster but uses a different
- * execution path than the Metadata API path since not all components are supported yet. The speed is usually
- * significant enough to justify using a specialized path.
+ * Preference page for controlling project's deployment options ('Right click project > Force.com > Deployments Options'). 
+ * As of v31, we are letting the user decide if they would prefer to use the Tooling API path when applicable (default). The 
+ * Tooling API is faster but uses a different execution path than the Metadata API path since not all components are supported yet. 
+ * The speed is usually significant enough to justify using a specialized path.
  * 
  * @author nchen
  * 
@@ -71,9 +71,11 @@ public class DeploymentOptions extends BasePropertyPage {
         deploymentComposite.setLayout(gridLayout);
         deploymentComposite.setLayoutData(new GridData(SWT.BEGINNING, SWT.TOP, false, false));
 
+        // 'Right click project > Force.com > Deployments Options > Use Tooling API Deploy path when possible'
         preferToolingDeploymentCheckbox = new Button(deploymentComposite, SWT.CHECK);
         preferToolingDeploymentCheckbox.setText(UIMessages.getString("DeploymentOptions_UseToolingAPI"));
 
+        // 'Right click project > Force.com > Deployments Options > Disable 'Save to Server' dirty resource check'
         disableSaveToServerDirtyResourceCheckCheckbox = new Button(deploymentComposite, SWT.CHECK);
         disableSaveToServerDirtyResourceCheckCheckbox.setText(UIMessages.getString("DeploymentOptions_DisableSaveToServerDirtyResourceCheck"));;
         

--- a/com.salesforce.ide.ui/src/com/salesforce/ide/ui/properties/DeploymentOptions.java
+++ b/com.salesforce.ide.ui/src/com/salesforce/ide/ui/properties/DeploymentOptions.java
@@ -35,6 +35,7 @@ import com.salesforce.ide.ui.internal.utils.UIMessages;
 public class DeploymentOptions extends BasePropertyPage {
 
     private Button preferToolingDeploymentCheckbox;
+    private Button disableSaveToServerDirtyResourceCheckCheckbox;
     private ProjectController projectController = null;
     private ForceProject forceProject;
 
@@ -73,6 +74,9 @@ public class DeploymentOptions extends BasePropertyPage {
         preferToolingDeploymentCheckbox = new Button(deploymentComposite, SWT.CHECK);
         preferToolingDeploymentCheckbox.setText(UIMessages.getString("DeploymentOptions_UseToolingAPI"));
 
+        disableSaveToServerDirtyResourceCheckCheckbox = new Button(deploymentComposite, SWT.CHECK);
+        disableSaveToServerDirtyResourceCheckCheckbox.setText(UIMessages.getString("DeploymentOptions_DisableSaveToServerDirtyResourceCheck"));;
+        
         loadFromPreferences();
 
         return deploymentComposite;
@@ -82,6 +86,8 @@ public class DeploymentOptions extends BasePropertyPage {
         forceProject = getProjectService().getForceProject(getProject());
         boolean preferToolingDeployment = forceProject.getPreferToolingDeployment();
         preferToolingDeploymentCheckbox.setSelection(preferToolingDeployment);
+        
+        disableSaveToServerDirtyResourceCheckCheckbox.setSelection(forceProject.getDisableSaveToServerDirtyResourceCheck());
 
         projectController.getProjectModel().setForceProject(forceProject);
     }
@@ -90,6 +96,7 @@ public class DeploymentOptions extends BasePropertyPage {
     public boolean performOk() {
         try {
             forceProject.setPreferToolingDeployment(preferToolingDeploymentCheckbox.getSelection());
+            forceProject.setDisableSaveToServerDirtyResourceCheck(disableSaveToServerDirtyResourceCheckCheckbox.getSelection());
             projectController.saveSettings(new NullProgressMonitor());
         } catch (InterruptedException e) {
             // Not possible with a NullProgressMonitor


### PR DESCRIPTION
Due to the 'Type Save error: Package Visibility: Type is not visible: <foobar> #178 ' changed using tooling api deployment pathway by default to **false** and added an issue link to the option name in the options dialog. 

![image](https://cloud.githubusercontent.com/assets/273413/17898132/9e2ad65e-6924-11e6-938a-689b1cd2ea7f.png)
