### PR TITLE
Fix link syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Force.com IDE Core
 This is the core part of the Force.com IDE development tools for
 salesforce.com.
 
-For more information, refer to the [Force.com IDE page] [1].
+For more information, refer to the [Force.com IDE page][1].
 
 License
 -------


### PR DESCRIPTION
As it is, the `[1]` is a link and `[Force.com IDE page]` shows up as plain text, because there's a space between them. This fixes that.